### PR TITLE
Vendi php storm notices 

### DIFF
--- a/sqrl-login.php
+++ b/sqrl-login.php
@@ -354,7 +354,7 @@ class SQRLLogin {
 	 * Display screen in profile to associate or disassociate a SQRL login with a user
 	 * profile.
 	 *
-	 * @param object $user       User object of the associated user account.
+	 * @param WP_User $user       User object of the associated user account.
 	 */
 	public function associate_sqrl( $user ) {
 		$admin_post_path = wp_parse_url( admin_url( 'admin-post.php' ), PHP_URL_PATH );
@@ -366,14 +366,14 @@ class SQRLLogin {
 		?>
 		<h3><?php echo $sqrl_settings_title; ?></h3>
 		<?php
-		if ( get_user_meta( $user->id, 'sqrl_idk', true ) ) {
+		if ( get_user_meta( $user->ID, 'sqrl_idk', true ) ) {
 			?>
 			<table class="form-table">
 				<tr>
 					<th>
 					</th>
 					<td>
-						<?php if ( get_user_meta( $user->id, 'sqrl_hardlock', true ) ) { ?>
+						<?php if ( get_user_meta( $user->ID, 'sqrl_hardlock', true ) ) { ?>
 							<div class="sqrl-form" style="border-left: 3px solid #dc3232;">
 								<div class="sqrl-login-row"><?php echo $hardlock_disclaimer; ?></div>
 							</div>
@@ -469,10 +469,10 @@ class SQRLLogin {
 	 * Add the SQRL specific code. Used both from the profile screen and the login screen to
 	 * login users or associate them with a specific account.
 	 *
-	 * @param object $user       User object of the logged in user account.
-	 * @param bool   $associated True if the user is associated with a SQRL identity.
+	 * @param WP_User $user       User object of the logged in user account.
+	 * @param bool    $associated True if the user is associated with a SQRL identity.
 	 */
-	public function add_to_login_form( $user = false, $associated = false ) {
+	public function add_to_login_form( $user = null, $associated = false ) {
 		if ( get_option( 'users_can_register' ) ) {
 			$button_label = esc_html__( 'Sign in or Register with SQRL', 'sqrl' );
 			$qrcode_label = esc_html__( 'You may also sign in or register with SQRL using any SQRL-equipped smartphone by scanning this QR code.', 'sqrl' );
@@ -503,7 +503,7 @@ class SQRLLogin {
 			set_transient(
 				$nut,
 				array(
-					'user'        => $user->id,
+					'user'        => $user->ID,
 					'ip'          => $this->get_client_ip(),
 					'redir'       => isset( $_GET['redirect_to'] ) ? sanitize_text_field( wp_unslash( $_GET['redirect_to'] ) ) : '',
 					'session'     => $session,

--- a/sqrl-login.php
+++ b/sqrl-login.php
@@ -550,7 +550,7 @@ class SQRLLogin {
 					encoded-sqrl-url="<?php echo $this->base64url_encode( $sqrl_url ); ?>"
 					tabindex="-1"
 				>
-					<img src="<?php echo plugins_url( 'images/sqrl_outline.svg', __FILE__ ); ?>"/>
+					<img src="<?php echo plugins_url( 'images/sqrl_outline.svg', __FILE__ ); ?>" alt=""/>
 					<div><?php echo $button_label; ?></div>
 				</a>
 			</div>

--- a/sqrl-login.php
+++ b/sqrl-login.php
@@ -235,7 +235,7 @@ class SQRLLogin {
 	}
 
 	/**
-	 * Add the nut to the registation page in order to create a user
+	 * Add the nut to the registration page in order to create a user
 	 * that we later can associate with the identity saved under the current nut.
 	 */
 	public function add_registration_fields() {
@@ -255,7 +255,7 @@ class SQRLLogin {
 
 	/**
 	 * The last function in the chain to register a user and saving the identity
-	 * associtation on the user.
+	 * association on the user.
 	 *
 	 * @param object $user       User object to associate identity with.
 	 */
@@ -444,7 +444,7 @@ class SQRLLogin {
 	}
 
 	/**
-	 * Function to extract the domain and lenght of path from a site url.
+	 * Function to extract the domain and length of path from a site url.
 	 */
 	public function get_domain_and_path_length() {
 		$site_url    = explode( '://', get_site_url() );
@@ -834,7 +834,7 @@ class SQRLLogin {
 		}
 
 		/**
-		 * Check the user call that we have a valid pewvious if available signature for
+		 * Check the user call that we have a valid previous if available signature for
 		 * the current authentication.
 		 */
 		if ( ! empty( $client['pidk'] ) ) {
@@ -1312,7 +1312,7 @@ class SQRLLogin {
 			$message .= '<div id="login_error">' . esc_html__( 'The only allowed login method is SQRL for this account', 'sqrl' ) . '</div>';
 		}
 		if ( isset( $_GET['message'] ) && self::MESSAGE_ERROR === (int) $_GET['message'] ) {
-			$message .= '<div id="login_error">' . esc_html__( 'An error occured with the last SQRL command, please try again.', 'sqrl' ) . '</div>';
+			$message .= '<div id="login_error">' . esc_html__( 'An error occurred with the last SQRL command, please try again.', 'sqrl' ) . '</div>';
 		}
 		if ( isset( $_GET['message'] ) && self::MESSAGE_REGISTRATION_NOT_ALLOWED === (int) $_GET['message'] ) {
 			$message .= '<div id="login_error">' . esc_html__( 'The site is not allowing new registrations and your SQRL identity is not associated with any account.', 'sqrl' ) . '</div>';
@@ -1520,7 +1520,7 @@ class SQRLLogin {
 
 	/**
 	 * This function will create a random username. This will be used to create anonymous logins
-	 * when registring a new user.
+	 * when registering a new user.
 	 *
 	 * @param string $prefix    String appended before the random number of this anonymous user.
 	 */

--- a/sqrl-login.php
+++ b/sqrl-login.php
@@ -1010,7 +1010,7 @@ class SQRLLogin {
 				}
 
 				/*
-				 * Check if we should associate an old user or create a new one. Checking if registring users
+				 * Check if we should associate an old user or create a new one. Checking if registering users
 				 * are allowed on the current installation.
 				 */
 				if ( $user ) {

--- a/sqrl-login.php
+++ b/sqrl-login.php
@@ -632,6 +632,8 @@ class SQRLLogin {
 			$this->only_allow_base64_url( $session_key );
 		}
 
+		$session_nut = null;
+
 		// Validate nut value.
 		// If the string is not Base64URL encoded, die here and don't process code below.
 		if ( isset( $_GET['nut'] ) ) {
@@ -673,7 +675,7 @@ class SQRLLogin {
 			wp_set_auth_cookie( $session['user'] );
 		}
 
-		$disabled = get_user_meta( $wp_users[0], 'sqrl_disable_user', true );
+		$disabled = get_user_meta( $session['user'], 'sqrl_disable_user', true );
 		if ( $disabled ) {
 			$this->logout_with_message( self::MESSAGE_DISABLED );
 		} elseif ( ! empty( $session['redir'] ) ) {
@@ -1275,6 +1277,8 @@ class SQRLLogin {
 		// Get user meta.
 		$disabled = get_user_meta( $user->ID, 'sqrl_disable_user', true );
 		$sqrlonly = get_user_meta( $user->ID, 'sqrl_sqrlonly', true );
+
+		$login_url = site_url( 'wp-login.php', 'login' );
 
 		if ( '1' === $disabled && '1' === $sqrlonly ) {
 			wp_clear_auth_cookie();

--- a/sqrl-login.php
+++ b/sqrl-login.php
@@ -1248,6 +1248,8 @@ class SQRLLogin {
 	 * Check if a user account is disabled.
 	 *
 	 * @param object $client   Current client parameter sent from the client.
+	 *
+	 * @return bool|mixed
 	 */
 	private function account_disabled( $client ) {
 		/*
@@ -1305,6 +1307,8 @@ class SQRLLogin {
 	 * Code inspired by https://github.com/jaredatch/Disable-Users
 	 *
 	 * @param string $message  Original message.
+	 *
+	 * @return string
 	 */
 	public function user_login_message( $message = '' ) {
 		if ( isset( $_GET['message'] ) && self::MESSAGE_DISABLED === (int) $_GET['message'] ) {
@@ -1415,6 +1419,8 @@ class SQRLLogin {
 	 * from the system.
 	 *
 	 * @param string $idk_val    Identity key value used to lookup user id.
+	 *
+	 * @return false|mixed
 	 */
 	private function get_user_id( $idk_val ) {
 		if ( empty( $idk_val ) ) {
@@ -1444,6 +1450,8 @@ class SQRLLogin {
 	 * from the system.
 	 *
 	 * @param object $client    Current client parameter sent from the client.
+	 *
+	 * @return false|mixed
 	 */
 	private function get_server_unlock_key( $client ) {
 		if ( empty( $client['idk'] ) ) {
@@ -1472,6 +1480,8 @@ class SQRLLogin {
 	 * operations like enabling and removing accounts.
 	 *
 	 * @param object $client   Current client parameter sent from the client.
+	 *
+	 * @return false|mixed
 	 */
 	private function get_verify_unlock_key( $client ) {
 		if ( empty( $client['idk'] ) ) {
@@ -1501,6 +1511,8 @@ class SQRLLogin {
 	 * in the system.
 	 *
 	 * @param string $idk_val    Identity key value used see if the account is associated with a user.
+	 *
+	 * @return bool
 	 */
 	private function account_present( $idk_val ) {
 		if ( empty( $idk_val ) ) {
@@ -1528,6 +1540,8 @@ class SQRLLogin {
 	 * when registering a new user.
 	 *
 	 * @param string $prefix    String appended before the random number of this anonymous user.
+	 *
+	 * @return string
 	 */
 	private function get_random_unique_username( $prefix = '' ) {
 		$user_exists = 1;
@@ -1550,6 +1564,8 @@ class SQRLLogin {
 	 * not allowed characters before doing a regular base64 decoding and removing any padding.
 	 *
 	 * @param string $data   Data to encode into base64 url.
+	 *
+	 * @return string
 	 */
 	private function base64url_encode( $data ) {
 		$data = str_replace( array( '+', '/' ), array( '-', '_' ), base64_encode( $data ) );
@@ -1567,6 +1583,8 @@ class SQRLLogin {
 	 * not allowed characters before doing a regular base64 decoding and removing any padding.
 	 *
 	 * @param string $data   Data to decode from base64 url.
+	 *
+	 * @return string
 	 */
 	private function base64url_decode( $data ) {
 		return base64_decode( str_replace( array( '-', '_' ), array( '+', '/' ), $data ) );
@@ -1578,6 +1596,8 @@ class SQRLLogin {
 	 * it can have multiple equal characters present but will only split on the first one.
 	 *
 	 * @param string $str   String to split into a pair.
+	 *
+	 * @return array
 	 */
 	private function value_pair( $str ) {
 		$eq_pos = strpos( $str, '=' );

--- a/sqrl-login.php
+++ b/sqrl-login.php
@@ -817,6 +817,8 @@ class SQRLLogin {
 		 */
 		$admin_post_path = wp_parse_url( admin_url( 'admin-post.php' ), PHP_URL_PATH );
 
+		$result = false;
+
 		/**
 		 * Check the user call that we have a valid signature for the current authentication.
 		 */
@@ -866,6 +868,7 @@ class SQRLLogin {
 		 */
 		$server_hash = sanitize_text_field( wp_unslash( $_POST['server'] ) );
 		$server_str  = explode( "\r\n", $this->base64url_decode( $server_hash ) );
+		$server = array();
 		if ( count( $server_str ) === 1 ) {
 			$server_str = substr( $server_str[0], strpos( $server_str[0], '?' ) + 1 );
 			foreach ( explode( '&', $server_str ) as $k => $v ) {
@@ -873,7 +876,6 @@ class SQRLLogin {
 				$server[ $key ]    = $val;
 			}
 		} else {
-			$server = array();
 			foreach ( $server_str as $k => $v ) {
 				list( $key, $val ) = $this->value_pair( $v );
 				$server[ $key ]    = $val;


### PR DESCRIPTION
Issue #55

Description: Misc changes detected by PhpStorm

Changes:
I tried my best to space the changes out into different commits so that you could decide what you did or did not want to keep. These changes includes:

- Typos in comments and/or user-text: ec88500c71aafaf2f02b9cf11f7d96e2983261e9 and 0d85a1908239cc55ddc4d00e4ecab0a3ef899cb0
- Updating DocBlocks with more explicit/correct types, as well as return types in some cases: ab9fb6463cca0f4fcfdd8e1590a6366f73bf7188 and e94d531d0608125998922278dcc4805a074a2b63
- Added an empty ALT attribute on an image: 574b7abac238bd75dc91ce557396e9cb38bb737e
- Fixed two undefined variables: ef98adf5fd6e6d13843c77aaaf609db46953180c
- Added explicit type-hinting for WP_User when possible: 57809a0e46708b36cf987014dd9f237351972370
- Explicitly define variables with default values that might become undefined because of `if` or `try` logic: e52ba4ee74d611f66d3473a170126690e650a0e8