### PR TITLE
PHP 8 notice to warning issue

### DIFF
--- a/sqrl-login.php
+++ b/sqrl-login.php
@@ -689,11 +689,13 @@ class SQRLLogin {
 				$this->logout_with_message( self::MESSAGE_REMOVED );
 			}
 		}
-		if ( self::MESSAGE_REGISTRATION_NOT_ALLOWED === $session['err'] ) {
-			$this->logout_with_message( self::MESSAGE_REGISTRATION_NOT_ALLOWED );
-		}
-		if ( self::MESSAGE_ERROR === $session['err'] ) {
-			$this->logout_with_message( self::MESSAGE_ERROR );
+		if (isset($session['err'])) {
+			if ( self::MESSAGE_REGISTRATION_NOT_ALLOWED === $session['err'] ) {
+				$this->logout_with_message( self::MESSAGE_REGISTRATION_NOT_ALLOWED );
+			}
+			if ( self::MESSAGE_ERROR === $session['err'] ) {
+				$this->logout_with_message( self::MESSAGE_ERROR );
+			}
 		}
 
 		if ( self::COMMAND_REGISTER === $session['cmd'] ) {


### PR DESCRIPTION
Issue #.
Could be related to #64

Description:
Fixes an issue in which prevents someone from logging in because of changes with PHP 8 handling errors.

Root cause, if a key is undefined, PHP before 8.0 would treat this as a notice, and notices by default were hidden. PHP 8 upgraded this to a warning, so even if someone switched error_reporting to PHP 7.x days, these two if statements would still print out an error on successful logins about an undefined key.

Fixes https://sqrl.grc.com/threads/php-version-support.1261/

Changes:
Surround the error handling with an if statement that checks if the err key is set before checking the value.
